### PR TITLE
Cope with Letsencrypt rate limits

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,11 +11,10 @@ RUN cd /usr/local/letsencrypt-0.3.0 \
 
 RUN ln -s /root/.local/share/letsencrypt/bin/letsencrypt /usr/local/bin/letsencrypt
 
-COPY cert-sync /usr/local/bin/
-
-COPY httpd-foreground /usr/local/bin/
+COPY bin/* /usr/local/bin/
 
 ENV cert_delay=1
+ENV cert_single
 # Commented out because we don't want defaults
 #ENV cert_domains
 #ENV cert_email

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ RUN ln -s /root/.local/share/letsencrypt/bin/letsencrypt /usr/local/bin/letsencr
 COPY bin/* /usr/local/bin/
 
 ENV cert_delay=1
-ENV cert_single
+ENV cert_single=true
 # Commented out because we don't want defaults
 #ENV cert_domains
 #ENV cert_email

--- a/bin/cert-converge
+++ b/bin/cert-converge
@@ -7,11 +7,11 @@
 # Multiple replicas need to share /etc/letsencrypt as volume and make sure only one at a time is renewing certs.
 # We also need to bypass renew for existing certs until X days before expiry.
 
-if [ -n "${cert_email+1}" ]; then
+if [ -n "${cert_delay+1}" ]; then
+  echo "Pausing for $cert_delay seconds before converging certs"
   sleep "$cert_delay"
 fi
 
-EMAIL=${cert_email}
 DOMAINS=(${cert_domains})
 
 if [ -z "$DOMAINS" ]; then
@@ -19,24 +19,27 @@ if [ -z "$DOMAINS" ]; then
   exit 1
 fi
 
-if [ -z "$EMAIL" ]; then
-  echo "ERROR: Email is empty string or unset"
-  exit 1
+if [ -n "${LETSENCRYPT_ENDPOINT+1}" ]; then
+  sed -i 's/^server =/^#server =/' /etc/letsencrypt/cli.ini
+  echo "server = $LETSENCRYPT_ENDPOINT" >> /etc/letsencrypt/cli.ini
 fi
 
-if [ -n "${LETSENCRYPT_ENDPOINT+1}" ]; then
-  echo "server = $LETSENCRYPT_ENDPOINT" >> /etc/letsencrypt/cli.ini
+if [ "${cert_single}" ]; then
+  domain_args=""
+  for i in "${DOMAINS[@]}"
+  do
+    domain_args="$domain_args -d $i"
+  done
+  cert-renew ${domain_args:3}
+  exit $?
 fi
 
 for i in "${DOMAINS[@]}"
 do
   if [ -d "/etc/letsencrypt/live/$i" ]; then
-    echo "Cert found for domain $i"
+    echo "Cert found for host $i"
   else
     echo "Requesting cert for domain $i..."
-    letsencrypt certonly \
-      --text --renew-by-default --agree-tos \
-      --email=$EMAIL \
-      -d $i
+    cert-renew $i
   fi
 done

--- a/bin/cert-converge
+++ b/bin/cert-converge
@@ -32,6 +32,7 @@ if [ "${cert_single}" ]; then
   done
   cert-renew ${domain_args:3}
   exit $?
+  # TODO before exit we should probably symlink from the first domain to each alt name, to allow consistent config between single/individual certs
 fi
 
 for i in "${DOMAINS[@]}"

--- a/bin/cert-renew
+++ b/bin/cert-renew
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+if [ -z "${cert_email}" ]; then
+  echo "ERROR: cert_email env is empty string or unset"
+  exit 1
+fi
+
+letsencrypt certonly \
+  --text --renew-by-default --agree-tos \
+  --email=${cert_email} \
+  -d $@

--- a/bin/httpd-foreground
+++ b/bin/httpd-foreground
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 
-cert-sync
+cert-converge
 
 # Apache gets grumpy about PID files pre-existing
 rm -f /usr/local/apache2/logs/httpd.pid

--- a/cert-sync
+++ b/cert-sync
@@ -24,17 +24,19 @@ if [ -z "$EMAIL" ]; then
   exit 1
 fi
 
-domain_args=""
-for i in "${DOMAINS[@]}"
-do
-  domain_args="$domain_args -d $i"
-done
-
 if [ -n "${LETSENCRYPT_ENDPOINT+1}" ]; then
   echo "server = $LETSENCRYPT_ENDPOINT" >> /etc/letsencrypt/cli.ini
 fi
 
-letsencrypt certonly \
-  --text --renew-by-default --agree-tos \
-  $domain_args \
-  --email=$EMAIL
+for i in "${DOMAINS[@]}"
+do
+  if [ -d "/etc/letsencrypt/live/$i" ]; then
+    echo "Cert found for domain $i"
+  else
+    echo "Requesting cert for domain $i..."
+    letsencrypt certonly \
+      --text --renew-by-default --agree-tos \
+      --email=$EMAIL \
+      -d $i
+  fi
+done


### PR DESCRIPTION
In our hosting scenario we can not plan for new subdomains. A new one is needed every few weeks.

That makes certs with subjectAltName impractical, as it forces us to renew all certs as a new one is needed. Instead we use [SNI](https://en.wikipedia.org/wiki/Server_Name_Indication) to serve the right cert for each host, and the container should identify need for a new cert on startup.

This assumes that we have `/etc/letsencrypt` survive container replication. A persistent volume will do that, but we probably need some kind of locking to prevent multiple containers from requesting the same cert.

Multi-host certs (as done in https://github.com/solsson/ssl-proxy-letsencrypt and http://blog.ployst.com/development/2015/12/22/letsencrypt-on-kubernetes.html) can still be a useful mode. An env like `cert_single` could toggle to that mode. But we should add symlinking to the other hostnames, as `/etc/letsencrypt/live/[first-host]` does not indicate its alt names. Means the script should check if host path exists, not if if is a dir.

As a note here we should review our bash syntax. There are a couple of conventions in https://github.com/GoogleCloudPlatform/nginx-ssl-proxy/blob/master/start.sh that we partially follow thanks to not starting from scratch.

Furthermore, how do we trigger renewal? Have some script looking at expiry date and deleting `/etc/letsencrypt/live/[host]` accordingly?

And how do we keep all this within letsencrypt cert limits, or more specifically how do we minimize the number of cert requests?
