### PR TITLE
Fix 404 at git clone

### DIFF
--- a/git/Dockerfile
+++ b/git/Dockerfile
@@ -43,8 +43,8 @@ RUN depsRuntime=' \
 
 EXPOSE 80
 
-RUN sed -i 's|^#LoadModule cgid_module|LoadModule cgid_module|' conf/httpd.conf \
-  && sed -i 's|^#LoadModule rewrite_module|LoadModule rewrite_module|' conf/httpd.conf \
+RUN sed -i 's|#LoadModule cgid_module|LoadModule cgid_module|' conf/httpd.conf \
+  && sed -i 's|#LoadModule rewrite_module|LoadModule rewrite_module|' conf/httpd.conf \
   && echo "Include conf/git/*.conf" >> conf/httpd.conf
 
 ADD conf/git.conf /usr/local/apache2/conf/git/


### PR DESCRIPTION
Tests using build-contract would have caught this.
